### PR TITLE
Add diamond-diff to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 * [0xpm](https://0xpm.app/) - Diamond-based smart contract package manager.
 * [diamond-etherscan](https://github.com/zdenham/diamond-etherscan) - Make your EIP-2535 Diamond etherscan compatible.
 * [Diamantair](https://diamantaire.xyz/) -  Deploying new diamonds from a template.
+* [diamond-diff](https://www.npmjs.com/package/diamond-diff) - Tool that helps retrieve the necessary `diamondCut` by checking against a Diamond model.
 
 
 # Audits


### PR DESCRIPTION
Hi @mudgen . Created this tool to help retrieve what's the necessary `diamondCut` on a Diamond X to make it match with another Diamond. This tool can be helpful for projects that have a factory of facets and that needs to check off-chain if their deployed Diamonds follows a Diamond Model. 

More info can be found in the repo: [diamond-diff](https://www.npmjs.com/package/diamond-diff)